### PR TITLE
Add Default Pair-Lines

### DIFF
--- a/src/linklist.vue
+++ b/src/linklist.vue
@@ -76,12 +76,21 @@ export default {
         }
       }
     },
+    defaultPairs: {
+      type: Array,
+      default: []
+    }
   },
   data() {
     return {
       active: {},
       pairs: []
     };
+  },
+  updated() {
+    if (Array.isArray(this.defaultPairs) && this.pairs.length === 0) {
+      this.pairs = this.defaultPairs;
+    }
   },
   computed: {
     lines() {


### PR DESCRIPTION
If needs default pair-lines, pass to props `defaultPairs` like this,
```
<template>
<div id="app">
  link-list(:source="source" :defaultPairs="defaults")
</div>
</template>
```
Note render line execution in `updated()` because when default Pairs are computed within async function, it passed again after module loading.