### PR TITLE
fix error when click and drag-drop inside category

### DIFF
--- a/src/linklist.vue
+++ b/src/linklist.vue
@@ -173,11 +173,11 @@ export default {
     onDragStarted(categoryIndex, index, e) {
       this.dragCategoryIndex = categoryIndex;
       this.dragIndex = index;
-      this.dragY = e.offsetY;
+      this.dragY = e.layerY;
     },
     onDragging(e) {
       if (this.dragCategoryIndex === null) return;
-      this.dragY = e.offsetY;
+      this.dragY = e.layerY;
     },
     onDropped() {
       if (this.dragCategoryIndex === null) return;


### PR DESCRIPTION
## Release Note
categoryの中にクリック・Drag/Dropをすると正常に並び替える
## Team Name

- [x] TL

- [ ] DAC

- [ ] MembersEdge

- [ ] Others

## Type
- [ ] Feature

- [x] Bug fix

- [ ] Others

## How to confirm
Datafeed-v2でライブラリーを更新すると確認できます。
Before:
![10 -19-2018 15-43-37](https://user-images.githubusercontent.com/6301994/47202176-67dfdb80-d3b7-11e8-913b-84caa3207da6.gif)
After:
![10 -19-2018 15-42-05](https://user-images.githubusercontent.com/6301994/47202187-6d3d2600-d3b7-11e8-901e-98b52d42af47.gif)

## Remarks

## Review Check List

### 1st review
- [ ] Operation check
- [ ] Impact range confirmation
- [ ] Code review

### 2nd review
- [ ] Operation check
- [ ] Impact range confirmation
- [ ] Code review
