### PR TITLE
vuexでwarningが発生しないように修正する

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,27 @@
 export function moveAt({ array, index, at }) {
-  if (index === at || index > array.length -1 || at > array.length - 1) return array;
-  const value = array[index];
-  const tail = array.slice(index + 1);
-  array.splice(index);
-  Array.prototype.push.apply(array, tail);
-  array.splice(at, 0, value);
-  return array;
+  let lowerIndex = 0;
+  let higherIndex = 0;
+  if (index === at || index > array.length - 1 || at > array.length - 1) {
+    return array;
+  } else if (index > at) {
+    lowerIndex = at;
+    higherIndex = index;
+  } else {
+    lowerIndex = index;
+    higherIndex = at;
+  }
+  const element1 = Object.assign({}, array[higherIndex]);
+  element1.index = lowerIndex + 1;
+  const element2 = Object.assign({}, array[lowerIndex]);
+  element2.index = higherIndex + 1;
+  const slicedArray1 = array.slice(0, lowerIndex);
+  const slicedArray2 = array.slice(lowerIndex + 1, higherIndex);
+  const slicedArray3 = array.slice(higherIndex + 1);
+  let swappedArray = [];
+  swappedArray = slicedArray1;
+  swappedArray.push(element1);
+  swappedArray = swappedArray.concat(slicedArray2);
+  swappedArray.push(element2);
+  swappedArray = swappedArray.concat(slicedArray3);
+  return swappedArray;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,27 +1,10 @@
 export function moveAt({ array, index, at }) {
-  let lowerIndex = 0;
-  let higherIndex = 0;
-  if (index === at || index > array.length - 1 || at > array.length - 1) {
-    return array;
-  } else if (index > at) {
-    lowerIndex = at;
-    higherIndex = index;
-  } else {
-    lowerIndex = index;
-    higherIndex = at;
-  }
-  const element1 = Object.assign({}, array[higherIndex]);
-  element1.index = lowerIndex + 1;
-  const element2 = Object.assign({}, array[lowerIndex]);
-  element2.index = higherIndex + 1;
-  const slicedArray1 = array.slice(0, lowerIndex);
-  const slicedArray2 = array.slice(lowerIndex + 1, higherIndex);
-  const slicedArray3 = array.slice(higherIndex + 1);
-  let swappedArray = [];
-  swappedArray = slicedArray1;
-  swappedArray.push(element1);
-  swappedArray = swappedArray.concat(slicedArray2);
-  swappedArray.push(element2);
-  swappedArray = swappedArray.concat(slicedArray3);
+  if (index === at || index > array.length -1 || at > array.length - 1) return array;
+  let swappedArray = Object.assign([], array);
+  const value = swappedArray[index];
+  const tail = swappedArray.slice(index + 1);
+  swappedArray.splice(index);
+  Array.prototype.push.apply(swappedArray, tail);
+  swappedArray.splice(at, 0, value);
   return swappedArray;
 }


### PR DESCRIPTION
## Release Note
vuexでwarningが発生しないように修正する
```
Error: [vuex] Do not mutate vuex store state outside mutation handlers.
    at assert (login-db68f07047837ac90ef5.js:10194)
    at Vue.store._vm.$watch.deep (login-db68f07047837ac90ef5.js:10843)
    at Watcher.run (login-db68f07047837ac90ef5.js:15013)
    at Watcher.update (login-db68f07047837ac90ef5.js:14987)
    at Dep.notify (login-db68f07047837ac90ef5.js:12479)
    at Array.mutator (login-db68f07047837ac90ef5.js:12626)
    at moveAt (login-db68f07047837ac90ef5.js:175368)
    at VueComponent.onDropped (login-db68f07047837ac90ef5.js:175368)
    at mouseup (login-db68f07047837ac90ef5.js:175368)
    at invoker (login-db68f07047837ac90ef5.js:13807)
```
連携PR：
https://github.com/torchlight-dev/datafeed_v2/pull/180

**circleciを通らないくてもOKです**
## Team Name

- [x] TL

- [ ] DAC

- [ ] MembersEdge

- [ ] Others

## Type
- [ ] Feature

- [x] Bug fix

- [ ] Others

## How to confirm

## Remarks

## Review Check List

### 1st review
- [ ] Operation check
- [ ] Impact range confirmation
- [ ] Code review

### 2nd review
- [ ] Operation check
- [ ] Impact range confirmation
- [ ] Code review
