### PR TITLE
fixex: incorrect hightlight when drag-drop

### DIFF
--- a/example/src/App.vue
+++ b/example/src/App.vue
@@ -134,8 +134,5 @@ svg {
   line:hover {
     stroke: rgb(159, 100, 255);
   }
-  foreignObject {
-    user-select: none
-  }
 }
 </style>

--- a/src/linklist.vue
+++ b/src/linklist.vue
@@ -268,3 +268,8 @@ export default {
   }
 };
 </script>
+<style lang="scss" scoped>
+foreignObject {
+  user-select: none
+}
+</style>


### PR DESCRIPTION
## Release Note
Drag-dropしてから、テキストがhight-lightしちゃう問題。

https://github.com/torchlight-dev/datafeed_v2/issues/309

![1 -08-2019 18-37-06](https://user-images.githubusercontent.com/6301994/50895560-cc0bbc00-1449-11e9-93a2-748e95634c5e.gif)


**circleciを通らないくてもOKです**
## Team Name

- [x] TL

- [ ] DAC

- [ ] MembersEdge

- [ ] Others

## Type
- [ ] Feature

- [x] Bug fix

- [ ] Others

## How to confirm
- 動作確認お願いします。
- `cd example`
- `yarn install`
- `src/App.vue` の16・17行目を編集
```
//import Linklist from 'vue-linklist';
import Linklist from '../../src/';    // if you wanna develop
```
- `npm start`
- `localhost:8081/` にアクセス

## Remarks

## Review Check List

### 1st review
- [x] Operation check
- [x] Impact range confirmation
- [x] Code review

### 2nd review
- [x] Operation check
- [x] Impact range confirmation
- [x] Code review